### PR TITLE
MOB-21478

### DIFF
--- a/plugins/hh-geminio/CHANGELOG.md
+++ b/plugins/hh-geminio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Geminio
 
+## [1.1.8]
+### Fixed
+- Fixed duplication of projects in dependencies after recipe execution
+
 ## [1.1.7]
 ### Added
 - Support for Android Studio Arctic Fox | 2020.3.1

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.1.7
+pluginVersion=1.1.8
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-geminio

--- a/shared/core/code-modification/src/main/kotlin/ru/hh/plugins/code_modification/KtScriptsModificationService.kt
+++ b/shared/core/code-modification/src/main/kotlin/ru/hh/plugins/code_modification/KtScriptsModificationService.kt
@@ -39,7 +39,13 @@ class KtScriptsModificationService {
         val existingDependencies = dependenciesBodyBlock
             .children
             .filterIsInstance<KtCallExpression>()
-            .map { it.text.removePrefix("${it.calleeExpression?.text}(").removeSuffix(")") }
+            .map { ktCallExpression ->
+                ktCallExpression.text
+                    .removePrefix("${ktCallExpression.calleeExpression?.text}(")
+                    .removeSuffix(")")
+                    .removePrefix("project(\"")
+                    .removeSuffix("\")")
+            }
             .toSet()
 
         val ktPsiFactory = KtPsiFactory(ktFile.project)


### PR DESCRIPTION
- Исправляет ошибку с дублированием зависимостей вида `implementation(project(":shared:core:model"))` в `build.gradle.kts`-файлах выполнения команды рецепта `addDependencies`