### PR TITLE
Обновление поддержки Android Studio до 2021.1.1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci/new_android_studio
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,11 @@ jobs:
           wget -O android-studio.tar.gz -q $ANDROID_STUDIO_URL
           tar -xf android-studio.tar.gz -C ./
       - name: Build plugins
-        run: ./gradlew buildAllPlugins -DandroidStudioPath="$(pwd)/android-studio" -DandroidStudioCompilerVersion="$COMPILER_VERSION"
+        run: |
+          ./gradlew buildAllPlugins \
+            -DandroidStudioPath="$(pwd)/android-studio" \
+            -DandroidStudioCompilerVersion="$COMPILER_VERSION" \
+            -DandroidStudioPluginsNames="android,Kotlin,java,Groovy,git4idea,IntelliLang"
       - name: Publish plugins
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - ci/new_android_studio
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive
-  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2020.3.1.25/android-studio-2020.3.1.25-linux.tar.gz
-  COMPILER_VERSION: 203.7717.56
+  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.1.1.20/android-studio-2021.1.1.20-linux.tar.gz
+  COMPILER_VERSION: 211.7628.21
 
 jobs:
   build:
@@ -24,8 +24,8 @@ jobs:
           java-version: '11'
       - name: Download Android Studio
         run: |
-          wget -q $ANDROID_STUDIO_URL
-          tar -xf android-studio-2020.3.1.25-linux.tar.gz -C ./
+          wget -O android-studio.tar.gz -q $ANDROID_STUDIO_URL
+          tar -xf android-studio.tar.gz -C ./
       - name: Build plugins
         run: ./gradlew buildAllPlugins -DandroidStudioPath="$(pwd)/android-studio" -DandroidStudioCompilerVersion="$COMPILER_VERSION"
       - name: Publish plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,6 @@ systemProp.detektVersion=1.16.0
 
 systemProp.androidStudioPath=/Applications/Android Studio.app
 systemProp.androidStudioCompilerVersion=211.7628.21
-systemProp.androidStudioPluginsNames=android,android-layoutlib,Kotlin,java,Groovy,git4idea,IntelliLang
+systemProp.androidStudioPluginsNames=android,Kotlin,java,Groovy,git4idea,IntelliLang
 
 org.gradle.kotlin.dsl.caching.buildcache=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ systemProp.kotlinVersion=1.5.21
 systemProp.detektVersion=1.16.0
 
 systemProp.androidStudioPath=/Applications/Android Studio.app
-systemProp.androidStudioCompilerVersion=203.7717.56
+systemProp.androidStudioCompilerVersion=211.7628.21
 systemProp.androidStudioPluginsNames=android,android-layoutlib,Kotlin,java,Groovy,git4idea,IntelliLang
 
 org.gradle.kotlin.dsl.caching.buildcache=false

--- a/plugins/hh-carnival/gradle.properties
+++ b/plugins/hh-carnival/gradle.properties
@@ -1,7 +1,7 @@
-pluginVersion=1.1.5
+pluginVersion=1.1.6
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-carnival
 
-pluginSinceBuild=203.7717.56
-pluginUntilBuild=203.7717.56
+pluginSinceBuild=211.7628.21
+pluginUntilBuild=211.7628.21

--- a/plugins/hh-garcon/gradle.properties
+++ b/plugins/hh-garcon/gradle.properties
@@ -1,7 +1,7 @@
-pluginVersion=1.0.3
+pluginVersion=1.0.4
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-garcon
 
-pluginSinceBuild=203.7717.56
-pluginUntilBuild=203.7717.56
+pluginSinceBuild=211.7628.21
+pluginUntilBuild=211.7628.21

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -1,7 +1,7 @@
-pluginVersion=1.1.9
+pluginVersion=1.1.10
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-geminio
 
-pluginSinceBuild=203.7717.56
-pluginUntilBuild=203.7717.56
+pluginSinceBuild=211.7628.21
+pluginUntilBuild=211.7628.21

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/ConfigureTemplateParametersStepFactory.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/ConfigureTemplateParametersStepFactory.kt
@@ -7,6 +7,7 @@ import com.android.tools.idea.npw.project.getModuleTemplates
 import com.android.tools.idea.npw.project.getPackageForPath
 import com.android.tools.idea.npw.template.ConfigureTemplateParametersStep
 import com.android.tools.idea.projectsystem.NamedModuleTemplate
+import com.android.tools.idea.wizard.template.Category
 import com.android.tools.idea.wizard.template.FormFactor
 import com.android.tools.idea.wizard.template.Template
 import com.google.wireless.android.sdk.stats.AndroidStudioEvent
@@ -134,7 +135,8 @@ class ConfigureTemplateParametersStepFactory {
                 moduleParent = STUB_PARENT_MODULE_NAME,
                 projectSyncInvoker = ProjectSyncInvoker.DefaultProjectSyncInvoker(),
                 isLibrary = true,
-                formFactor = FormFactor.Mobile
+                formFactor = FormFactor.Mobile,
+                category = Category.Other
             ).also {
                 it.packageName.set(defaultPackageName)
                 it.template.set(namedModuleTemplate)

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
@@ -1,7 +1,7 @@
 package ru.hh.plugins.geminio.services.templates
 
-import com.android.tools.idea.templates.ModuleTemplateDataBuilder
-import com.android.tools.idea.templates.ProjectTemplateDataBuilder
+import com.android.tools.idea.npw.template.ModuleTemplateDataBuilder
+import com.android.tools.idea.npw.template.ProjectTemplateDataBuilder
 import com.android.tools.idea.templates.recipe.DefaultRecipeExecutor
 import com.android.tools.idea.templates.recipe.RenderingContext
 import com.android.tools.idea.wizard.template.ApiTemplateData

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
@@ -7,6 +7,7 @@ import com.android.tools.idea.templates.recipe.RenderingContext
 import com.android.tools.idea.wizard.template.ApiTemplateData
 import com.android.tools.idea.wizard.template.ApiVersion
 import com.android.tools.idea.wizard.template.BaseFeature
+import com.android.tools.idea.wizard.template.Category
 import com.android.tools.idea.wizard.template.FormFactor
 import com.android.tools.idea.wizard.template.Language
 import com.android.tools.idea.wizard.template.ModuleTemplateData
@@ -118,6 +119,7 @@ class GeminioRecipeExecutorFactoryService {
                 minApi = createStubApiVersion(),
                 appCompatVersion = STUB_API_VERSION,
             )
+            builder.category = Category.Other
         }.build()
     }
 

--- a/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/helpers/GeminioExpressionUtils.kt
+++ b/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/helpers/GeminioExpressionUtils.kt
@@ -2,6 +2,7 @@ package ru.hh.plugins.geminio.sdk.helpers
 
 import com.android.tools.idea.wizard.template.ApiTemplateData
 import com.android.tools.idea.wizard.template.ApiVersion
+import com.android.tools.idea.wizard.template.Category
 import com.android.tools.idea.wizard.template.FormFactor
 import com.android.tools.idea.wizard.template.Language
 import com.android.tools.idea.wizard.template.ModuleTemplateData
@@ -45,11 +46,9 @@ internal object GeminioExpressionUtils {
             projectTemplateData = ProjectTemplateData(
                 androidXSupport = true,
                 gradlePluginVersion = "6.3",
-                javaVersion = "1.8",
                 sdkDir = File("/AndroidSdk"),
                 language = Language.Kotlin,
                 kotlinVersion = "1.4.10",
-                buildToolsVersion = "4.1.1",
                 rootDir = File("/Project"),
                 applicationPackage = "com.example.myapplication",
                 includedFormFactorNames = mapOf(
@@ -67,7 +66,6 @@ internal object GeminioExpressionUtils {
             aidlDir = File("/Project/src/main/aidl/"),
             rootDir = File("/Project/"),
             isNewModule = false,
-            hasApplicationTheme = false,
             name = "mylibrary",
             isLibrary = true,
             packageName = "com.example.mylibrary",
@@ -82,7 +80,8 @@ internal object GeminioExpressionUtils {
                 minApi = ApiVersion(21, "21"),
                 appCompatVersion = 21,
             ),
-            viewBindingSupport = ViewBindingSupport.NOT_SUPPORTED
+            viewBindingSupport = ViewBindingSupport.NOT_SUPPORTED,
+            category = Category.Other
         )
     }
 


### PR DESCRIPTION
- Обновил CI/CD
- Поднял поддерживаемую версию Android Studio до 2021.1.1.20 и поправил ошибки

Артефакты для тестирования можно взять тут: https://github.com/LionZXY/android-multimodule-plugin/releases/tag/build-22