### PR TITLE
Add predefined features parameters

### DIFF
--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/extensions/PredefinedFeaturesSectionExt.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/extensions/PredefinedFeaturesSectionExt.kt
@@ -1,6 +1,7 @@
 package ru.hh.plugins.geminio.sdk.recipe.models.extensions
 
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection
 
 

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeature.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeature.kt
@@ -2,7 +2,7 @@ package ru.hh.plugins.geminio.sdk.recipe.models.predefined
 
 
 enum class PredefinedFeature(
-    val yamlKey: String
+    val yamlKey: String,
 ) {
     /**
      * Adds two additional string parameters for modules creation:

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeatureParameter.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeatureParameter.kt
@@ -1,0 +1,7 @@
+package ru.hh.plugins.geminio.sdk.recipe.models.predefined
+
+sealed class PredefinedFeatureParameter {
+    data class ModuleCreationParameter(
+        val defaultPackageNamePrefix: String = "ru.hh"
+    ) : PredefinedFeatureParameter()
+}

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeaturesSection.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeaturesSection.kt
@@ -2,7 +2,7 @@ package ru.hh.plugins.geminio.sdk.recipe.models.predefined
 
 
 data class PredefinedFeaturesSection(
-    val features: Set<PredefinedFeature>
+    val features: Map<PredefinedFeature, PredefinedFeatureParameter>
 ) {
     companion object
 }

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
@@ -71,12 +71,3 @@ private fun Map<String, Any>.parseParameter(
         }
     }
 }
-
-/**
- * @return Returns a list if all elements of this list inherit T
- */
-@Suppress("UNCHECKED_CAST")
-private inline fun <reified T : Any> List<*>.checkItemsAre() =
-    if (all { it is T })
-        this as List<T>
-    else null

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
@@ -3,32 +3,80 @@
 package ru.hh.plugins.geminio.sdk.recipe.parsers.predefined
 
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection
 import ru.hh.plugins.geminio.sdk.recipe.parsers.ParsersErrorsFactory.sectionUnknownEnumKeyErrorMessage
 
 
 private const val KEY_PREDEFINED_FEATURES_SECTION = "predefinedFeatures"
 
+private const val KEY_PARAMETER_PREDEFINE_PACKAGE_NAME = "defaultPackageNamePrefix"
+
 
 /**
  * Parser from YAML to [ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection].
  */
 internal fun Map<String, Any>.toPredefinedFeaturesSection(): PredefinedFeaturesSection {
-    val featuresList = this[KEY_PREDEFINED_FEATURES_SECTION] as? List<String>
-        ?: return PredefinedFeaturesSection(emptySet())
+    val featuresSection = this[KEY_PREDEFINED_FEATURES_SECTION]
+        ?: return PredefinedFeaturesSection(emptyMap())
+    val featuresSectionList = featuresSection as? List<*> ?: return PredefinedFeaturesSection(emptyMap())
+
+    val featuresSectionMapList = featuresSectionList.map { feature ->
+        when (feature) {
+            is String -> { // If feature is just string
+                mapOf(feature to emptyMap<String, Any>())
+            }
+            is Map<*, *> -> { // If feature is map
+                feature.filterKeys { it is String } as Map<String, Any?>
+            }
+            else -> null
+        }
+    }.filterNotNull()
 
     return PredefinedFeaturesSection(
-        features = featuresList.mapTo(mutableSetOf()) { yamlKey ->
-            val result = PredefinedFeature.fromYamlKey(yamlKey)
-                ?: throw IllegalArgumentException(
-                    sectionUnknownEnumKeyErrorMessage(
-                        sectionName = KEY_PREDEFINED_FEATURES_SECTION,
-                        key = yamlKey,
-                        acceptableValues = PredefinedFeature.availableYamlKeys()
-                    )
-                )
-
-            result
-        }
+        features = featuresSectionMapList.associate { it.toPredefinedFeatureParameter() }
     )
 }
+
+private fun Map<String, Any?>.toPredefinedFeatureParameter(): Pair<PredefinedFeature, PredefinedFeatureParameter> {
+    for (feature in PredefinedFeature.values()) {
+        val parameterMap = this[feature.yamlKey] as? Map<String, Any>
+        if (parameterMap != null) {
+            return feature to parameterMap.parseParameter(feature)
+        }
+    }
+
+    throw IllegalArgumentException(
+        sectionUnknownEnumKeyErrorMessage(
+            sectionName = KEY_PREDEFINED_FEATURES_SECTION,
+            key = "${this.keys}",
+            acceptableValues = PredefinedFeature.availableYamlKeys()
+        )
+    )
+}
+
+private fun Map<String, Any>.parseParameter(
+    featureType: PredefinedFeature
+): PredefinedFeatureParameter {
+    return when (featureType) {
+        PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS -> {
+            val defaultPackageNamePrefix = this[KEY_PARAMETER_PREDEFINE_PACKAGE_NAME] as? String
+            if (defaultPackageNamePrefix == null) {
+                PredefinedFeatureParameter.ModuleCreationParameter()
+            } else {
+                PredefinedFeatureParameter.ModuleCreationParameter(
+                    defaultPackageNamePrefix = defaultPackageNamePrefix
+                )
+            }
+        }
+    }
+}
+
+/**
+ * @return Returns a list if all elements of this list inherit T
+ */
+@Suppress("UNCHECKED_CAST")
+private inline fun <reified T : Any> List<*>.checkItemsAre() =
+    if (all { it is T })
+        this as List<T>
+    else null

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/WidgetsInjector.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/WidgetsInjector.kt
@@ -6,12 +6,15 @@ import com.android.tools.idea.wizard.template.EnumParameter
 import com.android.tools.idea.wizard.template.EnumWidget
 import com.android.tools.idea.wizard.template.StringParameter
 import com.android.tools.idea.wizard.template.TextFieldWidget
+import com.android.tools.idea.wizard.template.impl.defaultPackageNameParameter
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_FORMATTED_MODULE_NAME_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_MODULE_NAME_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_PACKAGE_NAME_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.GLOBALS_SHOW_HIDDEN_VALUES_ID
 import ru.hh.plugins.geminio.sdk.recipe.models.GeminioRecipe
+import ru.hh.plugins.geminio.sdk.recipe.models.extensions.hasFeature
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection
 import ru.hh.plugins.geminio.sdk.template.aliases.AndroidStudioTemplateBuilder
 import ru.hh.plugins.geminio.sdk.template.aliases.AndroidStudioTemplateParameter
@@ -55,13 +58,16 @@ private fun GeminioRecipe.toParametersData(): GeminioRecipeParametersData {
 
     val allParameters = mutableListOf<GeminioTemplateParameterData>()
 
-    if (predefinedFeaturesSection.features.contains(PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS)) {
+    val moduleCreationParams = predefinedFeaturesSection.features[PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS]
+            as? PredefinedFeatureParameter.ModuleCreationParameter
+    if (moduleCreationParams != null) {
         val moduleNameParameterData = PredefinedFeaturesSection.createModuleNameParameter()
         val moduleNameStringParameter = moduleNameParameterData.parameter as AndroidStudioTemplateStringParameter
         val formattedModuleNameParameterData = PredefinedFeaturesSection.createFormattedModuleNameParameter(
             moduleNameParameter = moduleNameStringParameter
         )
         val packageNameParameterData = PredefinedFeaturesSection.createPackageNameParameter(
+            defaultPackageNamePrefix = moduleCreationParams.defaultPackageNamePrefix,
             moduleNameParameter = moduleNameStringParameter
         )
 

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/models/GeminioTemplateParameterData.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/models/GeminioTemplateParameterData.kt
@@ -3,7 +3,7 @@ package ru.hh.plugins.geminio.sdk.template.models
 import ru.hh.plugins.geminio.sdk.template.aliases.AndroidStudioTemplateParameter
 
 
-internal data class GeminioTemplateParameterData(
+internal data class GeminioTemplateParameterData constructor(
     val parameterId: String,
     val parameter: AndroidStudioTemplateParameter
 )

--- a/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/GeminioPredefinedFeatureSectionParserSpec.kt
+++ b/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/GeminioPredefinedFeatureSectionParserSpec.kt
@@ -1,0 +1,62 @@
+package ru.hh.plugins.geminio.sdk.recipe.parsers
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import org.yaml.snakeyaml.Yaml
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection
+import ru.hh.plugins.geminio.sdk.recipe.parsers.predefined.toPredefinedFeaturesSection
+
+internal class GeminioPredefinedFeatureSectionParserSpec : FreeSpec({
+    "Should support predefined feature section without params" {
+        val predefineSection = """
+            predefinedFeatures:
+                - enableModuleCreationParams
+        """.trimIndent()
+        val parsed: Map<String, Any> = Yaml().load(predefineSection)
+        val expected = PredefinedFeaturesSection(
+            mapOf(
+                PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS to
+                        PredefinedFeatureParameter.ModuleCreationParameter()
+            )
+        )
+
+        parsed.toPredefinedFeaturesSection() shouldBe expected
+    }
+
+    "Should support predefined feature section with defaultPackageNamePrefix" {
+        val testPackageNamePrefix = "ru.hh.test"
+        val predefineSection = """
+            predefinedFeatures:
+                - enableModuleCreationParams:
+                    defaultPackageNamePrefix: $testPackageNamePrefix
+        """.trimIndent()
+        val parsed: Map<String, Any> = Yaml().load(predefineSection)
+        val expected = PredefinedFeaturesSection(
+            mapOf(
+                PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS to
+                        PredefinedFeatureParameter.ModuleCreationParameter(testPackageNamePrefix)
+            )
+        )
+
+        parsed.toPredefinedFeaturesSection() shouldBe expected
+    }
+
+    "Should ignore if defaultPackageNamePrefix not exist" {
+        val predefineSection = """
+            predefinedFeatures:
+                - enableModuleCreationParams:
+                    someDifferentParam: other
+        """.trimIndent()
+        val parsed: Map<String, Any> = Yaml().load(predefineSection)
+        val expected = PredefinedFeaturesSection(
+            mapOf(
+                PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS to
+                        PredefinedFeatureParameter.ModuleCreationParameter()
+            )
+        )
+
+        parsed.toPredefinedFeaturesSection() shouldBe expected
+    }
+})


### PR DESCRIPTION
Сейчас нельзя поменять дефолтный префикс модулей, не пересобрав плагин.
Поэтому я добавил поддержку **опциональных** параметров для predefine features.

![image](https://user-images.githubusercontent.com/5871715/139415207-ae131973-c704-401d-b212-8a6a50bfe7c5.png)


Старый способ описания работает так же как и работал, без изменений