### PR TITLE
Correctly set template action group names

### DIFF
--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/GeminioStartupActivity.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/GeminioStartupActivity.kt
@@ -63,6 +63,12 @@ class GeminioStartupActivity : StartupActivity {
         rootDirPath: String,
         isModulesTemplates: Boolean
     ) {
+        val bundle = getTemplateActionsBundle(pluginConfig, isModulesTemplates)
+
+        val actionManager = ActionManager.getInstance()
+        val hhNewGroup = actionManager.getAction(bundle.templatesNewGroupId) as DefaultActionGroup
+        hhNewGroup.templatePresentation.text = bundle.templatesNewGroupName
+
         val rootDirectory = File(rootDirPath)
         if (rootDirectory.exists().not() || rootDirectory.isDirectory.not()) {
             println("Templates directory doesn't exists [path: $rootDirPath, isModulesTemplates: $isModulesTemplates]")
@@ -75,12 +81,6 @@ class GeminioStartupActivity : StartupActivity {
         println("\tTemplates count: ${templatesDirs.size}")
         println("============")
 
-        val actionManager = ActionManager.getInstance()
-
-        val bundle = getTemplateActionsBundle(pluginConfig, isModulesTemplates)
-
-        val hhNewGroup = actionManager.getAction(bundle.templatesNewGroupId) as DefaultActionGroup
-        hhNewGroup.templatePresentation.text = bundle.templatesNewGroupName
         val hhGenerateGroup = actionManager.getAction(bundle.templatesGenerateGroupId) as DefaultActionGroup
 
         templatesDirs.forEach { templateName ->


### PR DESCRIPTION
Currently if there's a template group which has no templates its name is not set correctly.
For example:

You have such config:
```
templatesRootDirPath: /config/geminio/templates
modulesTemplatesRootDirPath: /config/geminio/modules_templates

groupsNames:
  forNewGroup: Flipper Templates
  forNewModulesGroup: Flipper Modules
```
But you only have module templates.
Currently Geminio will skip configuration of action group which does not have templates assigned to it:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/668727/171455502-c6aa5406-d60d-491b-b025-23b42cf7c583.png">

This pull request fixes this behavior and provides correct name for the action group:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/668727/171456586-2ae51ce3-a9b9-4989-b99f-7fa13d66d61d.png">
