### PR TITLE
Add AS 2022.3.1 Beta 1 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ on: [pull_request, workflow_call]
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive
-  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.2.1.15/android-studio-2021.2.1.15-linux.tar.gz
-  COMPILER_VERSION: 212.5712.43
+  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.3.1.10/android-studio-2021.3.1.10-linux.tar.gz
+  COMPILER_VERSION: 213.7172.25
 
 jobs:
   build:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive
-  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.2.1.15/android-studio-2021.2.1.15-linux.tar.gz
-  COMPILER_VERSION: 212.5712.43
+  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.3.1.10/android-studio-2021.3.1.10-linux.tar.gz
+  COMPILER_VERSION: 213.7172.25
 
 jobs:
   build:

--- a/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-base.gradle.kts
+++ b/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-base.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.intellij.IntelliJPluginExtension
 import org.jetbrains.intellij.tasks.IntelliJInstrumentCodeTask
+import org.jetbrains.intellij.tasks.RunIdeTask
 import ru.hh.plugins.ExternalLibrariesExtension
 
 plugins {
@@ -29,5 +30,12 @@ tasks.getByName<IntelliJInstrumentCodeTask>("instrumentCode") {
     val currentVersion = Libs.chosenIdeaVersion
     if (currentVersion is ExternalLibrariesExtension.Product.LocalIde) {
         compilerVersion.set(currentVersion.compilerVersion)
+    }
+}
+
+tasks.getByName<RunIdeTask>("runIde") {
+    val currentVersion = Libs.chosenIdeaVersion
+    if (currentVersion is ExternalLibrariesExtension.Product.LocalIde) {
+        ideDir.set(File(currentVersion.pathToIdeForRun))
     }
 }

--- a/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin.gradle.kts
+++ b/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin.gradle.kts
@@ -32,7 +32,6 @@ configure<ChangelogPluginExtension> {
 tasks.withType<PatchPluginXmlTask> {
     version.set(properties("pluginVersion"))
     sinceBuild.set(properties("pluginSinceBuild"))
-    untilBuild.set(properties("pluginUntilBuild"))
 
     // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
     pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ systemProp.detektVersion=1.19.0
 
 systemProp.androidStudioPath=/Applications/Android Studio.app
 systemProp.runAndroidStudioPath=/Applications/Android Studio.app
-systemProp.androidStudioCompilerVersion=212.5712.43
+systemProp.androidStudioCompilerVersion=213.7172.25
 systemProp.androidStudioPluginsNames=android,Kotlin,java,Groovy,git4idea,IntelliLang
 
 org.gradle.kotlin.dsl.caching.buildcache=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ systemProp.kotlinVersion=1.6.10
 systemProp.detektVersion=1.19.0
 
 systemProp.androidStudioPath=/Applications/Android Studio.app
+systemProp.runAndroidStudioPath=/Applications/Android Studio.app
 systemProp.androidStudioCompilerVersion=212.5712.43
 systemProp.androidStudioPluginsNames=android,Kotlin,java,Groovy,git4idea,IntelliLang
 

--- a/libraries/src/main/kotlin/ru/hh/plugins/ExternalLibrariesExtension.kt
+++ b/libraries/src/main/kotlin/ru/hh/plugins/ExternalLibrariesExtension.kt
@@ -10,6 +10,7 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
     val javaVersion = JavaVersion.VERSION_11
     val chosenIdeaVersion: Product = Product.LocalIde(
         pathToIde = systemProperty("androidStudioPath").get(),
+        pathToIdeForRun = systemProperty("runAndroidStudioPath").get(),
         compilerVersion = systemProperty("androidStudioCompilerVersion").get(),
         pluginsNames = systemProperty("androidStudioPluginsNames").get()
             .split(',')
@@ -63,8 +64,9 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
         data class LocalIde(
             override val pluginsNames: List<String>,
             val pathToIde: String,
+            val pathToIdeForRun: String,
             // Для локальной версии Android Studio надо указывать версию компилятора для IntelliJInstrumentCodeTask
-            val compilerVersion: String
+            val compilerVersion: String,
         ) : Product()
 
         data class ICBasedIde(

--- a/plugins/hh-carnival/CHANGELOG.md
+++ b/plugins/hh-carnival/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Carnival
 
+## [1.1.8]
+### Added
+- Plugin no longer restricted to run on single IDE version
+
 ## [1.1.7]
 ### Added
 - Support for Android Studio Chipmunk | 2022.2.1

--- a/plugins/hh-carnival/gradle.properties
+++ b/plugins/hh-carnival/gradle.properties
@@ -4,4 +4,3 @@ pluginGroup=ru.hh.plugins
 pluginName=hh-carnival
 
 pluginSinceBuild=212.5712.43
-pluginUntilBuild=212.5712.43

--- a/plugins/hh-carnival/gradle.properties
+++ b/plugins/hh-carnival/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.1.7
+pluginVersion=1.1.8
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-carnival

--- a/plugins/hh-garcon/CHANGELOG.md
+++ b/plugins/hh-garcon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Garcon
 
+## [1.0.5]
+### Added
+- Plugin no longer restricted to run on single IDE version
+
 ## [1.0.4]
 ### Added
 - Support for Android Studio Chipmunk | 2022.2.1

--- a/plugins/hh-garcon/gradle.properties
+++ b/plugins/hh-garcon/gradle.properties
@@ -4,4 +4,3 @@ pluginGroup=ru.hh.plugins
 pluginName=hh-garcon
 
 pluginSinceBuild=212.5712.43
-pluginUntilBuild=212.5712.43

--- a/plugins/hh-garcon/gradle.properties
+++ b/plugins/hh-garcon/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.0.4
+pluginVersion=1.0.5
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-garcon

--- a/plugins/hh-geminio/CHANGELOG.md
+++ b/plugins/hh-geminio/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Geminio
 
+## [1.1.12]
+### Added
+- Plugin no longer restricted to run on single IDE version
+- Support for Android Studio Dolphin | 2022.3.1 Beta 1 
+
 ## [1.1.11]
 ### Added
 - Support for Android Studio Chipmunk | 2022.2.1

--- a/plugins/hh-geminio/build.gradle.kts
+++ b/plugins/hh-geminio/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     // Feature modules
     implementation(project(":shared:feature:geminio-sdk"))
 
+    // Stubs
+    compileOnly(project(":shared:core:android-studio-stubs"))
+
     // Libraries
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -4,4 +4,3 @@ pluginGroup=ru.hh.plugins
 pluginName=hh-geminio
 
 pluginSinceBuild=212.5712.43
-pluginUntilBuild=212.5712.43

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.1.11
+pluginVersion=1.1.12
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-geminio

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/module_template/ExecuteGeminioModuleTemplateAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/module_template/ExecuteGeminioModuleTemplateAction.kt
@@ -1,7 +1,6 @@
 package ru.hh.plugins.geminio.actions.module_template
 
 import com.android.tools.idea.gradle.actions.SyncProjectAction
-import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder
 import com.android.tools.idea.wizard.model.ModelWizard
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -21,6 +20,7 @@ import ru.hh.plugins.geminio.services.balloonError
 import ru.hh.plugins.geminio.services.balloonInfo
 import ru.hh.plugins.geminio.services.templates.ConfigureTemplateParametersStepFactory
 import ru.hh.plugins.geminio.services.templates.GeminioRecipeExecutorFactoryService
+import ru.hh.plugins.geminio.util.StudioWizardDialogFactory
 import ru.hh.plugins.models.gradle.BuildGradleDependency
 import ru.hh.plugins.models.gradle.BuildGradleDependencyConfiguration
 
@@ -95,9 +95,9 @@ class ExecuteGeminioModuleTemplateAction(
             .addStep(chooseAppsStep)
             .build()
 
-        val dialog = StudioWizardDialogBuilder(wizard, WIZARD_TITLE)
-            .setProject(project)
-            .build()
+        val dialog =
+            StudioWizardDialogFactory(wizard, WIZARD_TITLE)
+                .create(project)
 
         wizard.addResultListener(object : ModelWizard.WizardListener {
             override fun onWizardFinished(result: ModelWizard.WizardResult) {

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/template/ExecuteGeminioTemplateAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/template/ExecuteGeminioTemplateAction.kt
@@ -1,7 +1,6 @@
 package ru.hh.plugins.geminio.actions.template
 
 import com.android.tools.idea.model.AndroidModel
-import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder
 import com.android.tools.idea.wizard.model.ModelWizard
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -17,6 +16,7 @@ import ru.hh.plugins.geminio.sdk.GeminioSdkFactory
 import ru.hh.plugins.geminio.services.balloonError
 import ru.hh.plugins.geminio.services.balloonInfo
 import ru.hh.plugins.geminio.services.templates.ConfigureTemplateParametersStepFactory
+import ru.hh.plugins.geminio.util.StudioWizardDialogFactory
 import ru.hh.plugins.psi_utils.kotlin.shortReferencesAndReformatWithCodeStyle
 import kotlin.system.measureTimeMillis
 
@@ -103,9 +103,9 @@ class ExecuteGeminioTemplateAction(
             })
         }
 
-        val dialog = StudioWizardDialogBuilder(wizard, WIZARD_TITLE)
-            .setProject(project)
-            .build()
+        val dialog =
+            StudioWizardDialogFactory(wizard, WIZARD_TITLE)
+                .create(project)
         dialog.show()
     }
 

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/Studio2022Point2AndLowerWizardDialogFactory.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/Studio2022Point2AndLowerWizardDialogFactory.kt
@@ -1,0 +1,17 @@
+package ru.hh.plugins.geminio.util
+
+import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder
+import com.android.tools.idea.wizard.model.ModelWizard
+import com.android.tools.idea.wizard.model.ModelWizardDialog
+import com.intellij.openapi.project.Project
+
+class Studio2022Point2AndLowerWizardDialogFactory(
+    private val wizard: ModelWizard,
+    private val title: String,
+) : StudioWizardDialogFactory {
+    override fun create(project: Project): ModelWizardDialog {
+        return StudioWizardDialogBuilder(wizard, title)
+            .setProject(project)
+            .build()
+    }
+}

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/Studio2022Point3WizardDialogFactory.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/Studio2022Point3WizardDialogFactory.kt
@@ -1,0 +1,17 @@
+package ru.hh.plugins.geminio.util
+
+import com.android.tools.idea.wizard.model.ModelWizard
+import com.android.tools.idea.wizard.model.ModelWizardDialog
+import com.android.tools.idea.wizard.ui.StudioWizardDialogBuilder
+import com.intellij.openapi.project.Project
+
+class Studio2022Point3WizardDialogFactory(
+    private val wizard: ModelWizard,
+    private val title: String,
+) : StudioWizardDialogFactory {
+    override fun create(project: Project): ModelWizardDialog {
+        return StudioWizardDialogBuilder(wizard, title)
+            .setProject(project)
+            .build()
+    }
+}

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/StudioWizardDialogFactory.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/util/StudioWizardDialogFactory.kt
@@ -1,0 +1,19 @@
+package ru.hh.plugins.geminio.util
+
+import com.android.tools.idea.wizard.model.ModelWizard
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+
+interface StudioWizardDialogFactory {
+    fun create(project: Project): DialogWrapper
+
+    companion object {
+        operator fun invoke(wizard: ModelWizard, title: String): StudioWizardDialogFactory {
+            return try {
+                Studio2022Point2AndLowerWizardDialogFactory(wizard, title)
+            } catch (e: ClassNotFoundException) {
+                Studio2022Point3WizardDialogFactory(wizard, title)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ include(":shared:core:ui")
 include(":shared:core:code-modification")
 include(":shared:core:models")
 include(":shared:core:psi-utils")
+include(":shared:core:android-studio-stubs")
 // endregion
 
 // region Shared features

--- a/shared/core/android-studio-stubs/README.md
+++ b/shared/core/android-studio-stubs/README.md
@@ -1,0 +1,3 @@
+# shared-core-android-studio-stubs
+
+Модуль со стабами для старых версий Android Studio.

--- a/shared/core/android-studio-stubs/build.gradle.kts
+++ b/shared/core/android-studio-stubs/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("convention.idea-plugin-library")
+}
+
+// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+}

--- a/shared/core/android-studio-stubs/src/main/kotlin/com/android/tools/idea/ui/wizard/StudioWizardDialogBuilder.kt
+++ b/shared/core/android-studio-stubs/src/main/kotlin/com/android/tools/idea/ui/wizard/StudioWizardDialogBuilder.kt
@@ -1,0 +1,28 @@
+package com.android.tools.idea.ui.wizard
+
+import com.android.tools.idea.wizard.model.ModelWizard
+import com.android.tools.idea.wizard.model.ModelWizardDialog
+import com.intellij.openapi.project.Project
+
+@Suppress("UNUSED_PARAMETER")
+class StudioWizardDialogBuilder(
+    wizard: ModelWizard,
+    title: String,
+) {
+    init {
+        throw NotImplementedError(ERROR)
+    }
+
+    fun setProject(project: Project): StudioWizardDialogBuilder {
+        throw NotImplementedError(ERROR)
+    }
+
+    fun build(): ModelWizardDialog {
+        throw NotImplementedError(ERROR)
+    }
+
+    companion object {
+        const val ERROR =
+            "This is stub for com.android.tools.idea.wizard.ui.StudioWizardDialogBuilder from Android Studio <= Chipmunk"
+    }
+}


### PR DESCRIPTION
This pull request:
- Adds support for AS 2022.3.1 Beta 1
- Keeps support for AS 2022.2.1
- Adds ability to run plugin in different IDE than compile one
- Removes upper bound of Intellij Platform version from plugin. This allows to use plugin on latest IDE versions if there's no breaking API changes.