### PR TITLE
Fix androidStudioPluginsNames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
           ./gradlew buildAllPlugins \
             -DandroidStudioPath="$(pwd)/android-studio" \
             -DandroidStudioCompilerVersion="$COMPILER_VERSION" \
-            -DandroidStudioPluginsNames="android,Kotlin,java,Groovy,git4idea,IntelliLang"
+            -DandroidStudioPluginsNames="org.jetbrains.android,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy,Git4Idea,org.intellij.intelliLang"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -31,7 +31,7 @@ jobs:
           ./gradlew buildAllPlugins \
             -DandroidStudioPath="$(pwd)/android-studio" \
             -DandroidStudioCompilerVersion="$COMPILER_VERSION" \
-            -DandroidStudioPluginsNames="android,Kotlin,java,Groovy,git4idea,IntelliLang"
+            -DandroidStudioPluginsNames="org.jetbrains.android,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy,Git4Idea,org.intellij.intelliLang"
       - name: Publish plugins
         uses: softprops/action-gh-release@v1
         env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ systemProp.detektVersion=1.22.0
 
 systemProp.androidStudioPath=/Applications/Android Studio.app/Contents
 systemProp.androidStudioCompilerVersion=222.4459.24
-systemProp.androidStudioPluginsNames=android,Kotlin,java,Groovy,git4idea,IntelliLang
+systemProp.androidStudioPluginsNames=org.jetbrains.android,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy,Git4Idea,org.intellij.intelliLang
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
Используем ID плагинов при задании зависимостей.
Требуется для поддержки Android Studio Giraffe / Hedgehog.

android, Kotlin, java, Groovy, git4idea, IntelliLang — это всё задание зависимости от забандленного плагина по его `directoryName` из `${androidStudioPath}/plugins/builtinRegistry-1.xml`.
Эти имена не стабильны. 
В Android Studio Giraffe плагин `Git4Idea` переехал из `git4idea` в `vcs-github`, а `intelliLang` — из `IntelliLang` в `platform-langInjection`, в результате плагин не собирается.
Использование ID плагина вместо `directoryName` позволяет собираться на любых версиях. Совместимость и работа плагина не ломаются.

В будущих версиях gradle-intellij-plugin при использовании `directoryName` плагина будет выдаваться предупреждение: https://github.com/JetBrains/gradle-intellij-plugin/issues/805



