### PR TITLE
Update AnAction

### DIFF
--- a/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/actions/jira/merge_develop_to_portfolio/JiraMergeDevelopToPortfolioAction.kt
+++ b/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/actions/jira/merge_develop_to_portfolio/JiraMergeDevelopToPortfolioAction.kt
@@ -1,5 +1,6 @@
 package ru.hh.android.plugin.actions.jira.merge_develop_to_portfolio
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import ru.hh.android.plugin.extensions.checkInsidePortfolioBranch
@@ -8,6 +9,8 @@ import ru.hh.android.plugin.services.git.GitService
 import ru.hh.android.plugin.services.jira.JiraRestClientService
 
 class JiraMergeDevelopToPortfolioAction : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/actions/modules/copy_module/CopyAndroidModuleAction.kt
+++ b/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/actions/modules/copy_module/CopyAndroidModuleAction.kt
@@ -1,5 +1,6 @@
 package ru.hh.android.plugin.actions.modules.copy_module
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.command.executeCommand
@@ -44,6 +45,8 @@ import kotlin.system.measureTimeMillis
  * Action for copy module.
  */
 class CopyAndroidModuleAction : AnAction() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/extensions/AnActionEventExt.kt
+++ b/plugins/hh-carnival/src/main/kotlin/ru/hh/android/plugin/extensions/AnActionEventExt.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.android.facet.AndroidFacet
-import org.jetbrains.kotlin.idea.util.module
+import org.jetbrains.kotlin.idea.base.util.module
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/RescanTemplatesAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/RescanTemplatesAction.kt
@@ -1,6 +1,7 @@
 package ru.hh.plugins.geminio.actions
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.psi.PsiDirectory
@@ -9,16 +10,12 @@ import ru.hh.plugins.geminio.ActionsHelper
 import ru.hh.plugins.logger.HHLogger
 import ru.hh.plugins.logger.HHNotifications
 
-class RescanTemplatesAction : AnAction() {
-
-    init {
-        with(templatePresentation) {
-            text = "Rescan Templates"
-            icon = AllIcons.Actions.Refresh
-            description = "Rescan folder with templates"
-            isEnabledAndVisible = true
-        }
-    }
+class RescanTemplatesAction : AnAction(
+    /* text = */ "Rescan Templates",
+    /* description = */ "Rescan folder with templates",
+    /* icon = */ AllIcons.Actions.Refresh,
+) {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/SetupGeminioConfigAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/SetupGeminioConfigAction.kt
@@ -5,15 +5,9 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
 import ru.hh.plugins.geminio.config.editor.GeminioPluginSettingsSearchableConfigurable
 
-class SetupGeminioConfigAction : AnAction() {
-
-    init {
-        with(templatePresentation) {
-            text = "Setup Config"
-            isEnabledAndVisible = true
-        }
-    }
-
+class SetupGeminioConfigAction : AnAction(
+    /* text = */ "Setup Config"
+) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         ShowSettingsUtil.getInstance()

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/module_template/ExecuteGeminioModuleTemplateAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/module_template/ExecuteGeminioModuleTemplateAction.kt
@@ -1,6 +1,7 @@
 package ru.hh.plugins.geminio.actions.module_template
 
 import com.android.tools.idea.wizard.model.ModelWizard
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.psi.PsiDirectory
@@ -32,7 +33,11 @@ class ExecuteGeminioModuleTemplateAction(
     private val actionText: String,
     private val actionDescription: String,
     private val geminioRecipePath: String
-) : AnAction() {
+) : AnAction(
+    /* text = */ actionText,
+    /* description = */ actionDescription,
+    /* icon = */ null
+) {
 
     companion object {
         private const val COMMAND_RECIPE_EXECUTION = "ExecuteGeminioModuleTemplateAction.RecipeExecution"
@@ -40,13 +45,7 @@ class ExecuteGeminioModuleTemplateAction(
         private const val WIZARD_TITLE = "Geminio Module wizard"
     }
 
-    init {
-        with(templatePresentation) {
-            text = actionText
-            description = actionDescription
-            isEnabledAndVisible = true
-        }
-    }
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/template/ExecuteGeminioTemplateAction.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/actions/template/ExecuteGeminioTemplateAction.kt
@@ -2,6 +2,7 @@ package ru.hh.plugins.geminio.actions.template
 
 import com.android.tools.idea.model.AndroidModel
 import com.android.tools.idea.wizard.model.ModelWizard
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
@@ -27,9 +28,13 @@ import kotlin.system.measureTimeMillis
  */
 class ExecuteGeminioTemplateAction(
     private val actionText: String,
-    private val actionDescription: String,
+    actionDescription: String,
     private val geminioRecipePath: String
-) : AnAction() {
+) : AnAction(
+    /* text = */ actionText,
+    /* description = */ actionDescription,
+    /* icon = */ null,
+) {
 
     companion object {
         private const val COMMAND_NAME = "ExecuteGeminioTemplateActionCommand"
@@ -38,13 +43,7 @@ class ExecuteGeminioTemplateAction(
         private const val WIZARD_TITLE = "Geminio wizard"
     }
 
-    init {
-        with(templatePresentation) {
-            text = actionText
-            description = actionDescription
-            isEnabledAndVisible = true
-        }
-    }
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         val dataContext = e.dataContext


### PR DESCRIPTION
* Проставлен `AnAction.getActionUpdateThread()` в AnAction, который требуется с IJ 2022.3+ (AS Giraffe): https://plugins.jetbrains.com/docs/intellij/api-notable-list-2022.html#intellij-platform-20223. 
В JiraMergeDevelopToPortfolioAction проставлен EDT, так как там выполняется работа с git, в остальных - BGT.
* Инициализация AnAction перенесена из init-блоков в конструкторы, убраны игнорируемые `isEnabledAndVisible`.
* Обновлен устаревший импорт `org.jetbrains.kotlin.idea.util.module`
