### PR TITLE
[MOB-32847] Исправляет создание файлов в папке androidTest

### DIFF
--- a/plugins/hh-geminio/CHANGELOG.md
+++ b/plugins/hh-geminio/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Geminio
 
 
+## [1.6.1]
+
+### Fixed
+
+- Fixed files creation in `androidTest` directory.
+
 ## [1.6.0]
 
 ### Added

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.6.0
+pluginVersion=1.6.1
 
 pluginGroup=ru.hh.plugins
 pluginName=hh-geminio


### PR DESCRIPTION
Обнаружили, что при создании файлов в папке androidTest диалог заполнения параметров появляется, а вот сами файлы не создаются. Оказалось, что в Giraffe что-то поменялось в логике создания `AndroidFacet.getModuleTemplates`, и у `NamedModuleTemplate` метод `getSrcDirectory` начал отдавать `null` --> файлы не создавались. Если руками заполнить путь --> всё будет ок. 

 