### PR TITLE
Add source set configuration

### DIFF
--- a/plugins/hh-geminio/docs/en/RECIPE_CONTENT.md
+++ b/plugins/hh-geminio/docs/en/RECIPE_CONTENT.md
@@ -28,6 +28,10 @@ optionalParams:
 predefinedFeatures:
   - enableModuleCreationParams:
       defaultPackageNamePrefix: ru.hh.test
+      # optional
+      defaultSourceCodeFolderName: java
+      # optional
+      defaultSourceSetName: main
 
 widgets:
   - stringParameter:

--- a/plugins/hh-geminio/docs/en/recipe_content/PREDEFINED_FEATURES.md
+++ b/plugins/hh-geminio/docs/en/recipe_content/PREDEFINED_FEATURES.md
@@ -22,6 +22,16 @@ predefinedFeatures:
 
 Here, `ru.hh.test` - new value of your custom package name.
 
+Similarly, you can set the `sourceSet` and the folder name (usually kotlin/java) inside the sourceSet:
+
+```yaml
+predefinedFeatures:
+  - enableModuleCreationParams:
+      defaultPackageNamePrefix: ru.hh.test
+      defaultSourceCodeFolderName: java
+      defaultSourceSetName: main
+```
+
 ---
 
 [Back to `recipe.yaml` content](../RECIPE_CONTENT.md)

--- a/plugins/hh-geminio/docs/ru/RECIPE_CONTENT.md
+++ b/plugins/hh-geminio/docs/ru/RECIPE_CONTENT.md
@@ -28,6 +28,10 @@ optionalParams:
 predefinedFeatures:
   - enableModuleCreationParams:
       defaultPackageNamePrefix: ru.hh.test
+      # optional
+      defaultSourceCodeFolderName: java
+      # optional
+      defaultSourceSetName: main
 
 widgets:
   - stringParameter:

--- a/plugins/hh-geminio/docs/ru/recipe_content/PREDEFINED_FEATURES.md
+++ b/plugins/hh-geminio/docs/ru/recipe_content/PREDEFINED_FEATURES.md
@@ -23,6 +23,16 @@ predefinedFeatures:
 
 Здесь `ru.hh.test` - значение нужного вам custom-пакета.
 
+Аналогично можно задать `sourceSet` и имя папки ( обычно kotlin/java ) внутри sourceSet:
+
+```yaml
+predefinedFeatures:
+  - enableModuleCreationParams:
+      defaultPackageNamePrefix: ru.hh.test
+      defaultSourceSetName: main
+      defaultSourceCodeFolderName: java
+```
+
 ---
 
 [Обратно к устройству "рецептов"](../RECIPE_CONTENT.md)

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/models/GeminioAndroidModulePaths.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/models/GeminioAndroidModulePaths.kt
@@ -11,25 +11,26 @@ import java.io.File
  */
 class GeminioAndroidModulePaths(
     private val basePath: String,
-    private val moduleName: String
+    private val moduleName: String,
+    sourceSet: String,
+    sourceCodeFolderName: String,
 ) : AndroidModulePaths {
 
     private companion object {
         const val LOG_TAG = "GeminioAndroidModulePaths"
-
-        const val MANIFEST_FOLDER_PATH = "src/main"
-        const val UI_TESTS_FOLDER_PATH = "src/androidTest"
-        const val UNIT_TESTS_FOLDER_PATH = "src/test"
-        const val RES_FOLDER_PATH = "src/main/res"
-        const val AIDL_FOLDER_PATH = "src/main/aidl"
-        const val SOURCES_FOLDER_PATH = "src/main/java"
     }
 
+    private val manifestFolderPath = "src/$sourceSet"
+    private val uiTestsFolderPath = "src/androidTest"
+    private val unitTestsFolderPath = "src/test"
+    private val resFolderPath = "src/$sourceSet/res"
+    private val aidlFolderPath = "src/$sourceSet/aidl"
+    private val sourcesFolderPath = "src/$sourceSet/$sourceCodeFolderName"
     private val moduleRootPath: String get() = "$basePath/$moduleName"
 
     override val manifestDirectory: File
         get() {
-            val manifestDirectoryPath = "$moduleRootPath/$MANIFEST_FOLDER_PATH"
+            val manifestDirectoryPath = "$moduleRootPath/$manifestFolderPath"
 
             log("getter for manifestDirectory | path: $manifestDirectoryPath")
             return File(manifestDirectoryPath)
@@ -45,28 +46,28 @@ class GeminioAndroidModulePaths(
 
     override val resDirectories: List<File>
         get() {
-            val resDirectoryPath = "$moduleRootPath/$RES_FOLDER_PATH"
+            val resDirectoryPath = "$moduleRootPath/$resFolderPath"
 
             log("getter for resDirectories | path: $resDirectoryPath")
             return listOf(File(resDirectoryPath))
         }
 
     override fun getAidlDirectory(packageName: String?): File {
-        val aidlDirectoryPath = "$moduleRootPath/$AIDL_FOLDER_PATH" + packageName?.toSlashedFilePath().orEmpty()
+        val aidlDirectoryPath = "$moduleRootPath/$aidlFolderPath" + packageName?.toSlashedFilePath().orEmpty()
 
         log("getter for getAidlDirectory(packageName: $packageName) | path: $aidlDirectoryPath")
         return File(aidlDirectoryPath)
     }
 
     override fun getSrcDirectory(packageName: String?): File {
-        val srcDirectoryPath = "$moduleRootPath/$SOURCES_FOLDER_PATH" + packageName?.toSlashedFilePath().orEmpty()
+        val srcDirectoryPath = "$moduleRootPath/$sourcesFolderPath" + packageName?.toSlashedFilePath().orEmpty()
 
         log("getter for getSrcDirectory(packageName: $packageName) | path: $srcDirectoryPath")
         return File(srcDirectoryPath)
     }
 
     override fun getTestDirectory(packageName: String?): File {
-        val testDirectoryPath = "$moduleRootPath/$UI_TESTS_FOLDER_PATH" + packageName?.toSlashedFilePath().orEmpty()
+        val testDirectoryPath = "$moduleRootPath/$uiTestsFolderPath" + packageName?.toSlashedFilePath().orEmpty()
 
         log("getter for getTestDirectory(packageName: $packageName) | path: $testDirectoryPath")
         return File(testDirectoryPath)
@@ -74,7 +75,7 @@ class GeminioAndroidModulePaths(
 
     override fun getUnitTestDirectory(packageName: String?): File {
         val unitTestDirectoryPath =
-            "$moduleRootPath/$UNIT_TESTS_FOLDER_PATH" + packageName?.toSlashedFilePath().orEmpty()
+            "$moduleRootPath/$unitTestsFolderPath" + packageName?.toSlashedFilePath().orEmpty()
 
         log("getter for getUnitTestDirectory(packageName: $packageName) | path: $unitTestDirectoryPath")
         return File(unitTestDirectoryPath)

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/ConfigureTemplateParametersStepFactory.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/ConfigureTemplateParametersStepFactory.kt
@@ -30,6 +30,8 @@ class ConfigureTemplateParametersStepFactory(
 
         const val STUB_MODULE_NAME = "stub_module_name"
         const val STUB_PARENT_MODULE_NAME = "stub_parent_module_name"
+        const val STUB_SOURCE_SET = "stub_source_set"
+        const val STUB_SOURCE_CODE_FOLDER_NAME = "stub_source_code_folder_name"
     }
 
     fun createFromAndroidFacet(
@@ -90,7 +92,9 @@ class ConfigureTemplateParametersStepFactory(
             name = NAMED_MODULE_TEMPLATE_NAME,
             paths = GeminioAndroidModulePaths(
                 basePath = directoryPath,
-                moduleName = STUB_MODULE_NAME
+                moduleName = STUB_MODULE_NAME,
+                sourceSet = STUB_SOURCE_SET,
+                sourceCodeFolderName = STUB_SOURCE_CODE_FOLDER_NAME,
             )
         )
     }

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/services/templates/GeminioRecipeExecutorFactoryService.kt
@@ -41,12 +41,16 @@ class GeminioRecipeExecutorFactoryService(
     ): GeminioRecipeExecutorModel {
         val moduleName = geminioTemplateData.getModuleName()
         val packageName = geminioTemplateData.getPackageName()
+        val sourceSet = geminioTemplateData.getSourceSet()
+        val sourceCodeFolderName = geminioTemplateData.getSourceCodeFolderName()
 
         val moduleTemplateData = createModuleTemplateData(
             project = project,
             directoryPath = newModuleRootDirectoryPath,
             moduleName = moduleName,
-            packageName = packageName
+            packageName = packageName,
+            sourceSet = sourceSet,
+            sourceCodeFolderName = sourceCodeFolderName
         )
 
         val renderingContext = RenderingContext(
@@ -71,7 +75,9 @@ class GeminioRecipeExecutorFactoryService(
         project: Project,
         directoryPath: String,
         moduleName: String,
-        packageName: String
+        packageName: String,
+        sourceSet : String,
+        sourceCodeFolderName : String,
     ): ModuleTemplateData {
         val projectTemplateDataBuilder = ProjectTemplateDataBuilder(isNewProject = false)
             .also { builder ->
@@ -92,7 +98,9 @@ class GeminioRecipeExecutorFactoryService(
             builder.setModuleRoots(
                 paths = GeminioAndroidModulePaths(
                     basePath = directoryPath,
-                    moduleName = moduleName
+                    moduleName = moduleName,
+                    sourceSet = sourceSet,
+                    sourceCodeFolderName = sourceCodeFolderName,
                 ),
                 projectPath = project.basePath!!,
                 moduleName = ":$moduleName",
@@ -129,5 +137,13 @@ class GeminioRecipeExecutorFactoryService(
 
     private fun GeminioTemplateData.getPackageName(): String {
         return existingParametersMap[geminioIds.newModulePackageNameParameterId]!!.value as String
+    }
+
+    private fun GeminioTemplateData.getSourceCodeFolderName(): String {
+        return existingParametersMap[geminioIds.newModuleSourceCodeFolderParameterId]!!.value as String
+    }
+
+    private fun GeminioTemplateData.getSourceSet(): String {
+        return existingParametersMap[geminioIds.newModuleSourceSetParameterId]!!.value as String
     }
 }

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/GeminioSdkConstants.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/GeminioSdkConstants.kt
@@ -5,6 +5,8 @@ internal object GeminioSdkConstants {
     const val FEATURE_FORMATTED_MODULE_NAME_PARAMETER_ID = "__formattedModuleName"
     const val FEATURE_PACKAGE_NAME_PARAMETER_ID = "__packageName"
     const val FEATURE_APPLICATIONS_MODULES_PARAMETER_ID = "__applicationsModules"
+    const val FEATURE_SOURCE_SET_PARAMETER_ID = "__sourceSet"
+    const val FEATURE_DEFAULT_SOURCE_CODE_FOLDER_PARAMETER_ID = "__srcCodeFolder"
 
     const val GLOBALS_SHOW_HIDDEN_VALUES_ID = "__showHiddenGlobals"
 }

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/models/GeminioTemplateParametersIds.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/models/GeminioTemplateParametersIds.kt
@@ -4,4 +4,6 @@ data class GeminioTemplateParametersIds(
     val newModuleNameParameterId: String,
     val newModulePackageNameParameterId: String,
     val newApplicationModulesParameterId: String,
+    val newModuleSourceSetParameterId: String,
+    val newModuleSourceCodeFolderParameterId: String,
 )

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeatureParameter.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/models/predefined/PredefinedFeatureParameter.kt
@@ -2,6 +2,14 @@ package ru.hh.plugins.geminio.sdk.recipe.models.predefined
 
 sealed class PredefinedFeatureParameter {
     data class ModuleCreationParameter(
-        val defaultPackageNamePrefix: String = "ru.hh"
-    ) : PredefinedFeatureParameter()
+        val defaultPackageNamePrefix: String = DEFAULT_PACKAGE_NAME_PREFIX,
+        val defaultSourceSet: String = DEFAULT_SOURCE_SET_NAME,
+        val defaultSourceCodeFolderName: String = DEFAULT_SOURCE_CODE_FOLDER_NAME,
+    ) : PredefinedFeatureParameter(){
+        companion object {
+            const val DEFAULT_PACKAGE_NAME_PREFIX = "ru.hh"
+            const val DEFAULT_SOURCE_SET_NAME = "main"
+            const val DEFAULT_SOURCE_CODE_FOLDER_NAME = "java"
+        }
+    }
 }

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/recipe/parsers/predefined/PredefinedFeaturesSectionParser.kt
@@ -4,11 +4,16 @@ package ru.hh.plugins.geminio.sdk.recipe.parsers.predefined
 
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter.ModuleCreationParameter.Companion.DEFAULT_SOURCE_CODE_FOLDER_NAME
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter.ModuleCreationParameter.Companion.DEFAULT_PACKAGE_NAME_PREFIX
+import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeatureParameter.ModuleCreationParameter.Companion.DEFAULT_SOURCE_SET_NAME
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection
 import ru.hh.plugins.geminio.sdk.recipe.parsers.ParsersErrorsFactory.sectionUnknownEnumKeyErrorMessage
 
 private const val KEY_PREDEFINED_FEATURES_SECTION = "predefinedFeatures"
 private const val KEY_PARAMETER_PREDEFINE_PACKAGE_NAME = "defaultPackageNamePrefix"
+private const val KEY_PARAMETER_SOURCE_NAME = "defaultSourceSetName"
+private const val KEY_PARAMETER_SOURCE_CODE_FOLDER_NAME = "defaultSourceCodeFolderName"
 
 /**
  * Parser from YAML to [ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeaturesSection].
@@ -62,13 +67,13 @@ private fun Map<String, Any>.parseParameter(
     return when (featureType) {
         PredefinedFeature.ENABLE_MODULE_CREATION_PARAMS -> {
             val defaultPackageNamePrefix = this[KEY_PARAMETER_PREDEFINE_PACKAGE_NAME] as? String
-            if (defaultPackageNamePrefix == null) {
-                PredefinedFeatureParameter.ModuleCreationParameter()
-            } else {
-                PredefinedFeatureParameter.ModuleCreationParameter(
-                    defaultPackageNamePrefix = defaultPackageNamePrefix
-                )
-            }
+            val defaultSourceSet = this[KEY_PARAMETER_SOURCE_NAME] as? String
+            val codeFolderName = this[KEY_PARAMETER_SOURCE_CODE_FOLDER_NAME] as? String
+            PredefinedFeatureParameter.ModuleCreationParameter(
+                defaultPackageNamePrefix = defaultPackageNamePrefix ?: DEFAULT_PACKAGE_NAME_PREFIX,
+                defaultSourceSet = defaultSourceSet ?: DEFAULT_SOURCE_SET_NAME,
+                defaultSourceCodeFolderName = codeFolderName ?: DEFAULT_SOURCE_CODE_FOLDER_NAME,
+            )
         }
     }
 }

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/GeminioRecipeMapper.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/GeminioRecipeMapper.kt
@@ -66,6 +66,8 @@ internal fun GeminioRecipe.toGeminioTemplateData(project: Project, targetDirecto
             newModuleNameParameterId = GeminioSdkConstants.FEATURE_MODULE_NAME_PARAMETER_ID,
             newModulePackageNameParameterId = GeminioSdkConstants.FEATURE_PACKAGE_NAME_PARAMETER_ID,
             newApplicationModulesParameterId = GeminioSdkConstants.FEATURE_APPLICATIONS_MODULES_PARAMETER_ID,
+            newModuleSourceSetParameterId = GeminioSdkConstants.FEATURE_SOURCE_SET_PARAMETER_ID,
+            newModuleSourceCodeFolderParameterId = GeminioSdkConstants.FEATURE_DEFAULT_SOURCE_CODE_FOLDER_PARAMETER_ID,
         ),
         paramsStore = paramsStore
     )

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/WidgetsInjector.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/WidgetsInjector.kt
@@ -7,8 +7,10 @@ import com.android.tools.idea.wizard.template.EnumWidget
 import com.android.tools.idea.wizard.template.StringParameter
 import com.android.tools.idea.wizard.template.TextFieldWidget
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_FORMATTED_MODULE_NAME_PARAMETER_ID
+import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_DEFAULT_SOURCE_CODE_FOLDER_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_MODULE_NAME_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_PACKAGE_NAME_PARAMETER_ID
+import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.FEATURE_SOURCE_SET_PARAMETER_ID
 import ru.hh.plugins.geminio.sdk.GeminioSdkConstants.GLOBALS_SHOW_HIDDEN_VALUES_ID
 import ru.hh.plugins.geminio.sdk.recipe.models.GeminioRecipe
 import ru.hh.plugins.geminio.sdk.recipe.models.predefined.PredefinedFeature
@@ -21,8 +23,10 @@ import ru.hh.plugins.geminio.sdk.template.mapping.widgets.globals.toGeminioTempl
 import ru.hh.plugins.geminio.sdk.template.mapping.widgets.globals.toShowHiddenGlobalsParameter
 import ru.hh.plugins.geminio.sdk.template.mapping.widgets.parameters.toGeminioTemplateParameterData
 import ru.hh.plugins.geminio.sdk.template.mapping.widgets.predefined.createFormattedModuleNameParameter
+import ru.hh.plugins.geminio.sdk.template.mapping.widgets.predefined.createSourceCodeFolderName
 import ru.hh.plugins.geminio.sdk.template.mapping.widgets.predefined.createModuleNameParameter
 import ru.hh.plugins.geminio.sdk.template.mapping.widgets.predefined.createPackageNameParameter
+import ru.hh.plugins.geminio.sdk.template.mapping.widgets.predefined.createSourceSetParameter
 import ru.hh.plugins.geminio.sdk.template.models.GeminioRecipeParametersData
 import ru.hh.plugins.geminio.sdk.template.models.GeminioTemplateParameterData
 
@@ -66,14 +70,24 @@ private fun GeminioRecipe.toParametersData(): GeminioRecipeParametersData {
             defaultPackageNamePrefix = moduleCreationParams.defaultPackageNamePrefix,
             moduleNameParameter = moduleNameStringParameter
         )
+        val sourceSetParameterData = PredefinedFeaturesSection.createSourceSetParameter(
+            defaultSourceSet = moduleCreationParams.defaultSourceSet,
+        )
+        val codeSourceSetFolderData = PredefinedFeaturesSection.createSourceCodeFolderName(
+            defaultSourceCodeFolderName = moduleCreationParams.defaultSourceCodeFolderName,
+        )
 
         allParameters += moduleNameParameterData
         allParameters += formattedModuleNameParameterData
         allParameters += packageNameParameterData
+        allParameters += sourceSetParameterData
+        allParameters += codeSourceSetFolderData
 
         existingParametersMap[FEATURE_MODULE_NAME_PARAMETER_ID] = moduleNameParameterData.parameter
         existingParametersMap[FEATURE_FORMATTED_MODULE_NAME_PARAMETER_ID] = formattedModuleNameParameterData.parameter
         existingParametersMap[FEATURE_PACKAGE_NAME_PARAMETER_ID] = packageNameParameterData.parameter
+        existingParametersMap[FEATURE_SOURCE_SET_PARAMETER_ID] = sourceSetParameterData.parameter
+        existingParametersMap[FEATURE_DEFAULT_SOURCE_CODE_FOLDER_PARAMETER_ID] = codeSourceSetFolderData.parameter
     }
 
     allParameters += widgetsSection.parameters.map { widgetParameter ->

--- a/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/predefined/PredefinedFeaturesParamsFactory.kt
+++ b/shared/feature/geminio-sdk/src/main/kotlin/ru/hh/plugins/geminio/sdk/template/mapping/widgets/predefined/PredefinedFeaturesParamsFactory.kt
@@ -62,3 +62,39 @@ internal fun PredefinedFeaturesSection.Companion.createPackageNameParameter(
         }
     )
 }
+
+internal fun PredefinedFeaturesSection.Companion.createSourceSetParameter(
+    defaultSourceSet: String,
+): GeminioTemplateParameterData {
+    return GeminioTemplateParameterData(
+        parameterId = GeminioSdkConstants.FEATURE_SOURCE_SET_PARAMETER_ID,
+        parameter = stringParameter {
+            name = "Source set"
+            help = "Source set of classes"
+            constraints = listOf(
+                AndroidStudioTemplateStringParameterConstraint.SOURCE_SET_FOLDER,
+                AndroidStudioTemplateStringParameterConstraint.UNIQUE,
+            )
+            default = defaultSourceSet
+            suggest = { defaultSourceSet }
+            visible = { true }
+            enabled = { true }
+        }
+    )
+}
+
+internal fun PredefinedFeaturesSection.Companion.createSourceCodeFolderName(
+    defaultSourceCodeFolderName: String,
+): GeminioTemplateParameterData {
+    return GeminioTemplateParameterData(
+        parameterId = GeminioSdkConstants.FEATURE_DEFAULT_SOURCE_CODE_FOLDER_PARAMETER_ID,
+        parameter = stringParameter {
+            name = "Code src folder name"
+            help = "Code src folder name (kotlin/java)"
+            default = defaultSourceCodeFolderName
+            visible = { true }
+            enabled = { true }
+        }
+    )
+}
+


### PR DESCRIPTION
Add two parameters to predefinedFeatures :

defaultSourceSetName: main
defaultSourceCodeFolderName: java

It can be used to create common kmm modules (`commonMain` source set + `kotlin` source folder name )