### PR TITLE
Migrate to IntelliJ Platform Gradle Plugin 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [pull_request, workflow_call]
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive
-  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2024.3.1.2/android-studio-2024.3.1.2-linux.tar.gz
+  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2024.2.2.13/android-studio-2024.2.2.13-linux.tar.gz
 
 jobs:
   build:
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Android Studio
         run: |
           wget -O android-studio.tar.gz -q $ANDROID_STUDIO_URL

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   # Link for Linux zip file from https://developer.android.com/studio/archive
-  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2024.2.1.9/android-studio-2024.2.1.9-linux.tar.gz
+  ANDROID_STUDIO_URL: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2024.2.2.13/android-studio-2024.2.2.13-linux.tar.gz
 
 jobs:
   build:
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Download Android Studio
         run: |
           wget -O android-studio.tar.gz -q $ANDROID_STUDIO_URL

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ google-services.json
 # OS specific
 .DS_Store
 *.log
+
+# Intellij plugins
+.intellijPlatform

--- a/build-logic/gradle-ext/collect-update-plugins/src/main/kotlin/ru/hh/plugins/gradle/collect_update_plugins/CollectUpdatePluginsXmlGradlePlugin.kt
+++ b/build-logic/gradle-ext/collect-update-plugins/src/main/kotlin/ru/hh/plugins/gradle/collect_update_plugins/CollectUpdatePluginsXmlGradlePlugin.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.hasPlugin
 import org.gradle.kotlin.dsl.register
-import org.jetbrains.intellij.tasks.PatchPluginXmlTask
+import org.jetbrains.intellij.platform.gradle.tasks.PatchPluginXmlTask
 import ru.hh.plugins.core_utils.Constants
 import ru.hh.plugins.core_utils.isRoot
 

--- a/build-logic/idea-convention/src/main/kotlin/PluginDescriptionValueSource.kt
+++ b/build-logic/idea-convention/src/main/kotlin/PluginDescriptionValueSource.kt
@@ -1,0 +1,36 @@
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.jetbrains.changelog.markdownToHTML
+
+/**
+ * Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
+ */
+abstract class PluginDescriptionValueSource : ValueSource<String, PluginDescriptionValueSource.Parameters> {
+    override fun obtain(): String? {
+        val readmeFile = parameters.readmeFilePath.get().asFile
+        val lines = readmeFile.readText().lines()
+
+        val start = lines.indexOf(DESCRIPTION_START_MARKER)
+        val end = lines.indexOf(DESCRIPTION_END_MARKER)
+
+        if (start < 0 || end < 0) {
+            throw GradleException(
+                "Plugin description section not found in README.md:\n" +
+                    "$DESCRIPTION_START_MARKER ... $DESCRIPTION_END_MARKER"
+            )
+        }
+
+        return lines.subList(start + 1, end).joinToString("\n").let(::markdownToHTML)
+    }
+
+    interface Parameters : ValueSourceParameters {
+        val readmeFilePath: RegularFileProperty
+    }
+
+    private companion object {
+        const val DESCRIPTION_START_MARKER = "<!-- Plugin description -->"
+        const val DESCRIPTION_END_MARKER = "<!-- Plugin description end -->"
+    }
+}

--- a/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-base.gradle.kts
+++ b/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-base.gradle.kts
@@ -1,39 +1,40 @@
-import org.gradle.kotlin.dsl.configure
-import org.jetbrains.intellij.IntelliJPluginExtension
-import org.jetbrains.intellij.tasks.BuildSearchableOptionsTask
-import org.jetbrains.intellij.tasks.InstrumentCodeTask
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import ru.hh.plugins.ExternalLibrariesExtension
+import java.nio.file.Path
 
 plugins {
     id("convention.kotlin-jvm")
-    id("org.jetbrains.intellij")
+    id("org.jetbrains.intellij.platform.base")
 }
 
-configure<IntelliJPluginExtension> {
-    type.set("AI")
+val currentVersion: ExternalLibrariesExtension.Product = Libs.chosenIdeaVersion
 
-    val currentVersion = Libs.chosenIdeaVersion
-    when (currentVersion) {
-        is ExternalLibrariesExtension.Product.ICBasedIde -> {
-            version.set(currentVersion.ideVersion)
+dependencies {
+    intellijPlatform {
+        when (currentVersion) {
+            is ExternalLibrariesExtension.Product.ICBasedIde -> {
+                androidStudio(currentVersion.ideVersion, useInstaller = true)
+
+                // XXX: Find a better way to add the bundled version of the plugin to the dependencies
+                intellijPlatform.plugin(Libs.androidStudioPlugin)
+            }
+            is ExternalLibrariesExtension.Product.LocalIde -> {
+                local(currentVersion.pathToIde)
+
+                // XXX: Find a better way to add the bundled version of the plugin to the dependencies
+                localPlugin(Path.of(currentVersion.pathToIde, "plugins/android").toString())
+            }
+            else -> error("Should not be reached")
         }
 
-        is ExternalLibrariesExtension.Product.LocalIde -> {
-            localPath.set(currentVersion.pathToIde)
-        }
-    }
-    plugins.set(currentVersion.pluginsNames)
-}
+        bundledPlugins(
+            "com.intellij.java",
+            "org.jetbrains.kotlin",
+        )
+        pluginVerifier()
+        testFramework(TestFrameworkType.Platform)
 
-tasks.getByName<InstrumentCodeTask>("instrumentCode") {
-    val currentVersion = Libs.chosenIdeaVersion
-    if (currentVersion is ExternalLibrariesExtension.Product.LocalIde) {
-        compilerVersion.set(currentVersion.compilerVersion)
+        // Workaround for https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-faq.html#junit5-test-framework-refers-to-junit4
+        testRuntimeOnly(ExternalLibrariesExtension.UnitTests.junit4)
     }
-}
-
-// Hack for removing errors "call to AnalyticsSettings before initialization"
-// https://issuetracker.google.com/issues/224810684?pli=1
-tasks.getByName<BuildSearchableOptionsTask>("buildSearchableOptions") {
-    enabled = false
 }

--- a/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-library.gradle.kts
+++ b/build-logic/idea-convention/src/main/kotlin/convention.idea-plugin-library.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("convention.idea-plugin-base")
+    id("org.jetbrains.intellij.platform.module")
 }

--- a/build-logic/testing-convention/src/main/kotlin/convention.unit-testing.gradle.kts
+++ b/build-logic/testing-convention/src/main/kotlin/convention.unit-testing.gradle.kts
@@ -9,9 +9,6 @@ plugins {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 
-    @Suppress("MagicNumber")
-    maxParallelForks = 8
-
     failFast = false
 
     /**

--- a/docs/geminio/geminio_support_new_android_studio.md
+++ b/docs/geminio/geminio_support_new_android_studio.md
@@ -38,52 +38,17 @@
 
    </details>
 
-4. Идём в корневой файл `gradle.properties` и локально меняем старую версию компилятора и путь к
-   локально установленной
+4. Идём в корневой файл `gradle.properties` и локально меняем путь к локально установленной
    Android Studio.
 
    ```properties
    systemProp.androidStudioPath=/Users/p.strelchenko/Applications/Android\ Studio\ Iguana\ 2023.2.1.app/Contents
-   systemProp.androidStudioCompilerVersion=232.10227.8
    ```
 
 5. Пытаемся запустить плагин `Geminio` через встроенную в проект конфигурацию `Geminio [RUN]`.
    Желательно заранее подготовить проект с шаблонами (обоих типов: и новых модулей, и новых файлов).
 
 6. Если API никак не поменялось, то запуск пройдёт успешно, все шаблоны будут работать корректно.
-
-### Известные проблемы
-
-#### Cannot find builtin plugin 'org.jetbrains.kotlin'
-
-Ошибка вида
-`Cannot find builtin plugin 'org.jetbrains.kotlin' for IDE: /Users/i.karenkov/Applications/Android Studio.app/Contents`
-указывает на то, что в плагинах установленной Android Studio не удалось найти Kotlin plugin.
-
-Это происходит из-за того, что мы всё ещё
-используем [Gradle IntelliJ Plugin (1.x)](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html),
-при этом актуальный плагин для работы с Android Studio начиная с Ladybug -
-это [IntelliJ Platform Gradle Plugin (2.x)](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html)
-
-**Как это хакнуть локально**
-
-1. Проверьте, есть ли в вашей Android Studio папка plugins/Kotlin. Итоговый путь
-   `path_to_as/plugins/Kotlin`.
-2. Если папка Kotlin есть, значит вам
-   поможет [это решение](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1176#issuecomment-1294811277).
-   Суть проблемы в том, что в файле `builtinRegistry-1.xml` отсутствует объявление
-   `org.jetbrains.kotlin`. Это можно
-   легко исправить, добавив в него
-   ```xml
-     <plugin directoryName="Kotlin" id="org.jetbrains.kotlin">
-       <dependencies>
-         <dependency>com.intellij.modules.platform</dependency>
-         <dependency>com.intellij.modules.java</dependency>
-         <dependency>com.intellij.modules.java-capable</dependency>
-         <dependency>com.intellij.java</dependency>
-       </dependencies>
-     </plugin>
-   ```
 
 ## Тестирование Geminio
 
@@ -112,8 +77,7 @@
 
 2. Вернуть обратно значение `systemProp.androidStudioPath`, локальное изменение коммитить нельзя.
 
-3. Заменить `pluginSinceBuild` в `gradle.properties` нужных плагинов на новую версию по аналогии с
-   `systemProp.androidStudioCompilerVersion`
+3. Заменить `pluginSinceBuild` в `gradle.properties` нужных плагинов на новую версию
 
 4. **Обновить URL для новой версии Android Studio**
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,13 @@ org.gradle.caching=false
 kotlin.parallel.tasks.in.project=true
 kotlin.code.style=official
 
-systemProp.gradleIntellijPluginVersion=1.16.0
-systemProp.gradleChangelogPluginVersion=2.1.2
+systemProp.gradleIntellijPluginVersion=2.2.1
+systemProp.gradleChangelogPluginVersion=2.2.1
 systemProp.kotlinVersion=1.9.21
 systemProp.detektVersion=1.23.4
 
 systemProp.androidStudioPath=/Applications/Android Studio.app/Contents
-systemProp.androidStudioCompilerVersion=242.21829.142
-systemProp.androidStudioPluginsNames=org.jetbrains.android,org.jetbrains.kotlin,com.intellij.java,org.intellij.groovy,Git4Idea,org.intellij.intelliLang
+systemProp.androidStudioPluginVersion=242.23726.103
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 # suppress inspection "UnusedProperty"

--- a/libraries/src/main/kotlin/ru/hh/plugins/ExternalLibrariesExtension.kt
+++ b/libraries/src/main/kotlin/ru/hh/plugins/ExternalLibrariesExtension.kt
@@ -7,25 +7,23 @@ import javax.inject.Inject
 
 abstract class ExternalLibrariesExtension @Inject constructor(private val providers: ProviderFactory) {
 
-    val javaVersion = JavaVersion.VERSION_17
+    val javaVersion = JavaVersion.VERSION_21
     val chosenIdeaVersion: Product = Product.LocalIde(
         pathToIde = systemProperty("androidStudioPath").get(),
-        compilerVersion = systemProperty("androidStudioCompilerVersion").get(),
-        pluginsNames = systemProperty("androidStudioPluginsNames").get()
-            .split(',')
-            .map(String::trim)
-            .filter(String::isNotEmpty)
     )
 
+    private val androidStudioPluginVersion = systemProperty("androidStudioPluginVersion").get()
     private val gradleIntellijPluginVersion = systemProperty("gradleIntellijPluginVersion").get()
     private val gradleChangelogPluginVersion = systemProperty("gradleChangelogPluginVersion").get()
     private val kotlinVersion = systemProperty("kotlinVersion").get()
     private val detektVersion = systemProperty("detektVersion").get()
 
     val kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-    val gradleIntelliJPlugin = "org.jetbrains.intellij.plugins:gradle-intellij-plugin:$gradleIntellijPluginVersion"
+    val gradleIntelliJPlugin =
+        "org.jetbrains.intellij.platform:org.jetbrains.intellij.platform.gradle.plugin:$gradleIntellijPluginVersion"
     val gradleChangelogPlugin = "org.jetbrains.intellij.plugins:gradle-changelog-plugin:$gradleChangelogPluginVersion"
 
+    val androidStudioPlugin = "org.jetbrains.android:$androidStudioPluginVersion"
     val kotlinXCli = "org.jetbrains.kotlinx:kotlinx-cli:0.2.1"
     val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     val kotlinStdlibJdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
@@ -44,6 +42,7 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
 
     object UnitTests {
         const val kotest = "io.kotest:kotest-runner-junit5-jvm:4.3.1"
+        const val junit4 = "junit:junit:4.13.2"
     }
 
     class StaticAnalysisLibraries(
@@ -57,128 +56,27 @@ abstract class ExternalLibrariesExtension @Inject constructor(private val provid
     }
 
     sealed class Product {
-
-        abstract val pluginsNames: List<String>
-
         data class LocalIde(
-            override val pluginsNames: List<String>,
             val pathToIde: String,
-            // For the local version of Android Studio,
-            // you must specify the compiler version for IntelliJInstrumentCodeTask (look into `About` screen)
-            val compilerVersion: String
         ) : Product()
 
         data class ICBasedIde(
-            override val pluginsNames: List<String>,
             val ideVersion: String
         ) : Product()
     }
 
     @Suppress("detekt.StringLiteralDuplication")
     enum class PredefinedIdeProducts(val product: Product) {
-        ANDROID_STUDIO_IGUANA(
+        ANDROID_STUDIO_LADYBUG_FEATURE_DROP(
             Product.ICBasedIde(
-                ideVersion = "232.10227.8",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                )
+                ideVersion = "242.23726.1",
             )
         ),
-
-        ANDROID_STUDIO_ARCTIC_FOX(
+        ANDROID_STUDIO_LADYBUG(
             Product.ICBasedIde(
-                ideVersion = "202.7660.26",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea",
-                    "IntelliLang"
-                )
+                ideVersion = "242.23339.11",
             )
         ),
-
-        ANDROID_STUDIO_4_2(
-            Product.ICBasedIde(
-                ideVersion = "202.7660.26",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea",
-                    "IntelliLang"
-                )
-            )
-        ),
-
-        IDEA_2020_2(
-            Product.ICBasedIde(
-                ideVersion = "2020.2",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea"
-                )
-            )
-        ),
-
-        ANDROID_STUDIO_4_1(
-            Product.ICBasedIde(
-                ideVersion = "201.8743.12",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea"
-                )
-            )
-        ),
-
-        ANDROID_STUDIO_4_0(
-            Product.ICBasedIde(
-                ideVersion = "193.6911.18",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea"
-                )
-            )
-        ),
-
-        ANDROID_STUDIO_3_6_3(
-            Product.ICBasedIde(
-                ideVersion = "192.7142.36",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "java",
-                    "Groovy",
-                    "git4idea"
-                )
-            )
-        ),
-
-        ANDROID_STUDIO_3_5_3(
-            Product.ICBasedIde(
-                ideVersion = "191.8026.42",
-                pluginsNames = listOf(
-                    "android",
-                    "Kotlin",
-                    "Groovy",
-                    "git4idea"
-                )
-            )
-        )
     }
 
     private fun systemProperty(name: String): Provider<String> {

--- a/plugins/hh-carnival/build.gradle.kts
+++ b/plugins/hh-carnival/build.gradle.kts
@@ -2,13 +2,22 @@ plugins {
     id("convention.idea-plugin")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-    maven("https://packages.atlassian.com/maven/repository/public")
+intellijPlatform {
+    pluginConfiguration {
+        id = "ru.hh.plugins.Carnival"
+        name = "Carnival"
+    }
 }
 
 dependencies {
+    intellijPlatform {
+        bundledPlugins(
+            "Git4Idea",
+            "org.intellij.groovy",
+            "org.intellij.intelliLang",
+        )
+    }
+
     // Core modules
     implementation(project(":shared:core:utils"))
     implementation(project(":shared:core:ui"))

--- a/plugins/hh-carnival/gradle.properties
+++ b/plugins/hh-carnival/gradle.properties
@@ -1,6 +1,2 @@
-pluginVersion=1.10.0
-
-pluginGroup=ru.hh.plugins
-pluginName=hh-carnival
-
-pluginSinceBuild=242.21829.142
+pluginVersion=1.11.0
+pluginSinceBuild=242.23726.103

--- a/plugins/hh-carnival/src/main/resources/META-INF/plugin.xml
+++ b/plugins/hh-carnival/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,4 @@
 <idea-plugin>
-    <id>ru.hh.plugins.Carnival</id>
-    <name>Carnival</name>
-    <vendor email="p.strelchenko@hh.ru" url="https://hh.ru">hh.ru</vendor>
-
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.kotlin</depends>
     <depends>org.intellij.groovy</depends>

--- a/plugins/hh-garcon/build.gradle.kts
+++ b/plugins/hh-garcon/build.gradle.kts
@@ -2,9 +2,11 @@ plugins {
     id("convention.idea-plugin")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
+intellijPlatform {
+    pluginConfiguration {
+        id = "ru.hh.plugins.Garcon"
+        name = "Garcon"
+    }
 }
 
 dependencies {
@@ -15,8 +17,5 @@ dependencies {
     implementation(project(":shared:core:psi-utils"))
     implementation(project(":shared:core:logger"))
     implementation(project(":shared:core:notifications"))
-
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("reflect"))
     implementation(Libs.freemarker)
 }

--- a/plugins/hh-garcon/gradle.properties
+++ b/plugins/hh-garcon/gradle.properties
@@ -1,6 +1,2 @@
-pluginVersion=1.8.0
-
-pluginGroup=ru.hh.plugins
-pluginName=hh-garcon
-
-pluginSinceBuild=241.15989.15
+pluginVersion=1.9.0
+pluginSinceBuild=242.23726.103

--- a/plugins/hh-garcon/src/main/resources/META-INF/plugin.xml
+++ b/plugins/hh-garcon/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,4 @@
 <idea-plugin>
-    <id>ru.hh.plugins.Garcon</id>
-    <name>Garcon</name>
-    <vendor email="p.strelchenko@hh.ru" url="https://hh.ru">hh.ru</vendor>
-
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.android</depends>
@@ -13,7 +9,7 @@
 
         <!-- region Live templates -->
         <defaultLiveTemplates file="liveTemplates/Garcon.xml"/>
-        
+
         <liveTemplateContext
                 contextId="ru.hh.android.plugins.garcon.live_templates.step"
                 implementation="ru.hh.plugins.garcon.live_templates.LiveTemplateStepContext"/>

--- a/plugins/hh-geminio/build.gradle.kts
+++ b/plugins/hh-geminio/build.gradle.kts
@@ -2,9 +2,11 @@ plugins {
     id("convention.idea-plugin")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
+intellijPlatform {
+    pluginConfiguration {
+        id = "ru.hh.plugins.Geminio"
+        name = "Geminio"
+    }
 }
 
 dependencies {
@@ -30,7 +32,5 @@ dependencies {
     implementation(project(":shared:feature:geminio-sdk"))
 
     // Libraries
-    implementation(kotlin("stdlib-jdk8"))
-    implementation(kotlin("reflect"))
     implementation(Libs.flexmark) // Markdown parser
 }

--- a/plugins/hh-geminio/gradle.properties
+++ b/plugins/hh-geminio/gradle.properties
@@ -1,6 +1,2 @@
-pluginVersion=1.11.0
-
-pluginGroup=ru.hh.plugins
-pluginName=hh-geminio
-
+pluginVersion=1.12.0
 pluginSinceBuild=242.21829.142

--- a/plugins/hh-geminio/src/main/resources/META-INF/plugin.xml
+++ b/plugins/hh-geminio/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,4 @@
 <idea-plugin>
-    <id>ru.hh.plugins.Geminio</id>
-    <name>Geminio</name>
-    <vendor email="p.strelchenko@hh.ru" url="https://hh.ru">hh.ru</vendor>
-
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.android</depends>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,9 @@
+import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
+
 pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-        maven("https://packages.atlassian.com/maven/repository/public")
     }
 
     fun systemProperty(name: String): Provider<String> {
@@ -19,7 +20,7 @@ pluginManagement {
             val pluginId = requested.id.id
 
             when {
-                pluginId == "org.jetbrains.intellij" ->
+                pluginId.startsWith("org.jetbrains.intellij.") ->
                     useVersion(gradleIntellijPluginVersion.get())
 
                 pluginId == "org.jetbrains.changelog" ->
@@ -35,12 +36,24 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.jetbrains.intellij.platform.settings")
+}
+
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
     repositories {
         mavenCentral()
-        gradlePluginPortal()
-        maven("https://packages.atlassian.com/maven/repository/public")
+        maven("https://packages.atlassian.com/maven/repository/public") {
+            mavenContent {
+                includeGroupAndSubgroups("""com.atlassian""")
+            }
+        }
+        intellijPlatform {
+            defaultRepositories()
+        }
     }
 }
 

--- a/shared/core/android-studio-stubs/build.gradle.kts
+++ b/shared/core/android-studio-stubs/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
     id("convention.idea-plugin-library")
 }
-
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}

--- a/shared/core/code-modification/build.gradle.kts
+++ b/shared/core/code-modification/build.gradle.kts
@@ -2,12 +2,8 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
+    intellijPlatform.bundledPlugin("org.intellij.groovy")
     implementation(project(":shared:core:utils"))
     implementation(project(":shared:core:models"))
     implementation(project(":shared:core:psi-utils"))

--- a/shared/core/freemarker/build.gradle.kts
+++ b/shared/core/freemarker/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation(Libs.freemarker)
 }

--- a/shared/core/logger/build.gradle.kts
+++ b/shared/core/logger/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
     id("convention.idea-plugin-library")
 }
-
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}

--- a/shared/core/models/build.gradle.kts
+++ b/shared/core/models/build.gradle.kts
@@ -1,11 +1,3 @@
 plugins {
-    id("convention.idea-plugin-library")
-}
-
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
-dependencies {
+    id("convention.kotlin-jvm")
 }

--- a/shared/core/notifications/build.gradle.kts
+++ b/shared/core/notifications/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
     id("convention.idea-plugin-library")
 }
-
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}

--- a/shared/core/psi-utils/build.gradle.kts
+++ b/shared/core/psi-utils/build.gradle.kts
@@ -2,12 +2,10 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
+    intellijPlatform {
+        bundledPlugins("org.intellij.groovy")
+    }
     implementation(project(":shared:core:models"))
     implementation(project(":shared:core:utils"))
 }

--- a/shared/core/ui/build.gradle.kts
+++ b/shared/core/ui/build.gradle.kts
@@ -2,13 +2,6 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation(project(":shared:core:utils"))
-
-    implementation(kotlin("stdlib-jdk8"))
 }

--- a/shared/core/utils/build.gradle.kts
+++ b/shared/core/utils/build.gradle.kts
@@ -2,12 +2,6 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation(project(":shared:core:logger"))
 }

--- a/shared/core/utils/src/main/kotlin/ru/hh/plugins/extensions/openapi/ModuleExt.kt
+++ b/shared/core/utils/src/main/kotlin/ru/hh/plugins/extensions/openapi/ModuleExt.kt
@@ -1,5 +1,6 @@
 package ru.hh.plugins.extensions.openapi
 
+import com.android.tools.idea.projectsystem.gradle.getHolderModule
 import com.android.tools.idea.util.androidFacet
 import com.intellij.openapi.module.Module
 import com.intellij.psi.PsiFile
@@ -29,7 +30,7 @@ fun Module.isAndroidAppModule(): Boolean {
      *
      * To remove these submodules we add this condition.
      */
-    val isHolderModule = this == androidFacet?.module
+    val isHolderModule = this == androidFacet?.module?.getHolderModule()
 
     return isAppProject && isHolderModule
 }

--- a/shared/feature/geminio-sdk/build.gradle.kts
+++ b/shared/feature/geminio-sdk/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
     id("convention.idea-plugin-library")
 }
 
-// TODO [build-logic] Look with a fresh eye, why this needs to be duplicated, if there is common dependency resolution in settings.gradle
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     // Core modules
     implementation(project(":shared:core:freemarker"))
@@ -16,7 +11,6 @@ dependencies {
     implementation(project(":shared:core:logger"))
 
     // Libraries
-    implementation(kotlin("stdlib-jdk8"))
     implementation(Libs.freemarker)
 
     testImplementation(Libs.tests.kotest) // for kotest framework

--- a/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/helpers/GeminioExpressionUtils.kt
+++ b/shared/feature/geminio-sdk/src/test/kotlin/ru/hh/plugins/geminio/sdk/helpers/GeminioExpressionUtils.kt
@@ -51,7 +51,7 @@ internal object GeminioExpressionUtils {
         return ModuleTemplateData(
             projectTemplateData = ProjectTemplateData(
                 androidXSupport = true,
-                agpVersion = AgpVersion.parse("6.3"),
+                agpVersion = AgpVersion(8, 0),
                 sdkDir = File("/AndroidSdk"),
                 language = Language.Kotlin,
                 kotlinVersion = "1.4.10",
@@ -62,7 +62,8 @@ internal object GeminioExpressionUtils {
                 ),
                 debugKeystoreSha1 = null,
                 overridePathCheck = false,
-                isNewProject = false
+                isNewProject = false,
+                additionalMavenRepos = listOf(),
             ),
             srcDir = File("/Project/src/main/kotlin/com/example/mylibrary/"),
             resDir = File("/Project/src/main/res/"),


### PR DESCRIPTION
Миграция на IntelliJ Platform Gradle Plugin 2

* IntelliJ Platform Gradle Plugin обновлен до 2.2.1 
* IntelliJ Changelog plugin обновлен 2.2.1
* Добавлена поддержка Android Studio Ladybug Feature Drop | 2024.2.2, с дропом предыдущих версий.
* JDK обновлен с 17 до 21, требуется для Intellij 2024.2.2

Сборка с ExternalLibrariesExtension.Product.ICBasedIde, скорее всего, сломана.  Для неё надо придумать, как при автоматическом скачивании студии компилироваться с забандленным в неё AS плагином, а не с вариантом от intellij. Они отличаются, хоть у них и одинаковые версии. Если собираться с intellij вариантом, то в рантайме возникают ошибки.
Для локальной студии сейчас это сделано через добавление зависимости в виде ` localPlugin(<путь к plugins/android студии>)`

Кнопка `Geminio [RUN]` вроде тоже сломана (не проверял), но её должны починить в будущих версиях IntelliJ Platform Gradle Plugin


