### PR TITLE
Rename setConfigFilePath() to withConfigFilePath()

### DIFF
--- a/plugins/hh-garcon/src/main/kotlin/ru/hh/plugins/garcon/config/GarconPluginConfig.kt
+++ b/plugins/hh-garcon/src/main/kotlin/ru/hh/plugins/garcon/config/GarconPluginConfig.kt
@@ -11,7 +11,7 @@ class GarconPluginConfig(
 ) : YamlConfigModel {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : YamlConfigModel> setConfigFilePath(configFilePath: String): T {
+    override fun <T : YamlConfigModel> withConfigFilePath(configFilePath: String): T {
         return this.copy(configFilePath = configFilePath) as T
     }
 
@@ -38,5 +38,4 @@ class GarconPluginConfig(
         var kakaoWidgetFQN: String = String.EMPTY,
         var idSuffixes: MutableList<String> = mutableListOf()
     )
-
 }

--- a/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/config/GeminioPluginConfig.kt
+++ b/plugins/hh-geminio/src/main/kotlin/ru/hh/plugins/geminio/config/GeminioPluginConfig.kt
@@ -12,7 +12,7 @@ class GeminioPluginConfig(
 ) : YamlConfigModel {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T : YamlConfigModel> setConfigFilePath(configFilePath: String): T {
+    override fun <T : YamlConfigModel> withConfigFilePath(configFilePath: String): T {
         return this.copy(configFilePath = configFilePath) as T
     }
 
@@ -36,5 +36,4 @@ class GeminioPluginConfig(
         var forNewGroup: String = String.EMPTY,
         var forNewModulesGroup: String = String.EMPTY
     )
-
 }

--- a/shared/core/utils/src/main/kotlin/ru/hh/plugins/utils/yaml/YamlConfigModel.kt
+++ b/shared/core/utils/src/main/kotlin/ru/hh/plugins/utils/yaml/YamlConfigModel.kt
@@ -4,6 +4,6 @@ interface YamlConfigModel {
 
     var configFilePath: String
 
-    fun <T : YamlConfigModel> setConfigFilePath(configFilePath: String): T
+    fun <T : YamlConfigModel> withConfigFilePath(configFilePath: String): T
 
 }

--- a/shared/core/utils/src/main/kotlin/ru/hh/plugins/utils/yaml/YamlUtils.kt
+++ b/shared/core/utils/src/main/kotlin/ru/hh/plugins/utils/yaml/YamlUtils.kt
@@ -15,7 +15,7 @@ object YamlUtils {
             onError = {
                 return Result.failure(it)
             }
-        )?.setConfigFilePath<T>(configFilePath = configFilePath)
+        )?.withConfigFilePath<T>(configFilePath = configFilePath)
 
         return if (configFromYaml != null) {
             Result.success(configFromYaml)


### PR DESCRIPTION
`YamlConfigModel.setConfigFilePath()` переименован в `YamlConfigModel.withConfigFilePath()`.

Должно исправить иногда возникающие без причины  ошибки "Geminio's config is not valid (may be not configured at all)".

Десериализатор, используемый в PersistentStateComponent для чтения сохраненных настроек из `.idea/geminio_plugin_settings.xml`, основан на рефлексии, и он иногда путает сеттер свойства `var configFilePath` с этим методом `setConfigFilePath()`, в результате значение для `configFilePath` уходит в пустоту. 
Так как правильное значение поля не восстановлено, пользователь получает ошибку "Geminio's config is not valid",  а в настройках это поле становится пустым.
